### PR TITLE
Update KlipperScreen-install.sh

### DIFF
--- a/scripts/KlipperScreen-install.sh
+++ b/scripts/KlipperScreen-install.sh
@@ -9,7 +9,7 @@ FBDEV="xserver-xorg-video-fbdev"
 PYTHON="python3-virtualenv virtualenv python3-distutils"
 PYGOBJECT="libgirepository1.0-dev gcc libcairo2-dev pkg-config python3-dev gir1.2-gtk-3.0"
 MISC="librsvg2-common libopenjp2-7 wireless-tools libdbus-glib-1-dev autoconf"
-OPTIONAL="xserver-xorg-legacy fonts-nanum fonts-ipafont libmpv-dev policykit-1 network-manager"
+OPTIONAL="xserver-xorg-legacy fonts-nanum fonts-ipafont libmpv-dev policykit-1"
 
 Red='\033[0;31m'
 Green='\033[0;32m'


### PR DESCRIPTION
Fixes #29
`network-manager` is most likely not needed.
Previous installs didn't need it, installing it messes up the install process.