### PR TITLE
Bug correction in temperature.py to show the screen temperature

### DIFF
--- a/panels/temperature.py
+++ b/panels/temperature.py
@@ -500,7 +500,7 @@ class Panel(ScreenPanel):
                 #script,
             #)
             if not self.pid_start or not self.pid_end:
-                "script": f"PID_CALIBRATE HEATER={self.active_heater} TARGET={temp}"
+                script = {"script": f"PID_CALIBRATE HEATER={self.active_heater} TARGET={temp}"}
                 self._screen._confirm_send_action(
                     None,
                     _("Initiate a PID calibration for:")
@@ -511,7 +511,7 @@ class Panel(ScreenPanel):
                     script,
                 )
             else:
-                "script": f"_PID_KS_START\nPID_CALIBRATE HEATER={self.active_heater} TARGET={temp}\n_PID_KS_END"
+                script = {"script": f"_PID_KS_START\nPID_CALIBRATE HEATER={self.active_heater} TARGET={temp}\n_PID_KS_END"}
                 self._screen._confirm_send_action(
                     None,
                     _("Initiate a PID calibration for:")


### PR DESCRIPTION
CORRECTION FIX OF THIS ERROR :


2024-05-13 20:50:55,467 [screen.py:_load_panel()] - Loading panel: temperature
2024-05-13 20:50:55,523 [screen.py:show_error_modal()] - Showing error modal: Unable to load panel temperature illegal target for annotation (temperature.py, line 503)

Traceback (most recent call last):
  File "/home/pi/KlipperScreen/screen.py", line 310, in show_panel
    self.panels[panel_name] = self._load_panel(panel).Panel(self, title, **kwargs)
  File "/home/pi/KlipperScreen/screen.py", line 297, in _load_panel
    return import_module(f"panels.{panel}")
  File "/usr/lib/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 844, in exec_module
  File "<frozen importlib._bootstrap_external>", line 981, in get_code
  File "<frozen importlib._bootstrap_external>", line 911, in source_to_code
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/home/pi/KlipperScreen/panels/temperature.py", line 503
    "script": f"PID_CALIBRATE HEATER={self.active_heater} TARGET={temp}"
    ^
SyntaxError: illegal target for annotation